### PR TITLE
added support for TCP ports in firewall config

### DIFF
--- a/fw/fw-config
+++ b/fw/fw-config
@@ -4,6 +4,10 @@
 
 VPN_INTERFACE="tun+"
 
+# OpenVPN ports used by major providers:
+OPENVPN_UDP_PORTS="53,1194,1195,1196,1197,1198,1301,1302"
+OPENVPN_TCP_PORTS="80,110,443,501,502"
+
 # get path for this script
 working_path="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -235,9 +239,6 @@ fi
 
 printf "Configuring firewall rules...\\n"
 
-# OpenVPN ports used by major providers:
-OPENVPN_UDP_PORTS="53,1194,1195,1196,1197,1198,1301,1302"
-
 # delete all existing rules
 iptables -Z
 iptables --flush
@@ -289,7 +290,12 @@ EOF
 		# add outbound services rules
 		firewall_script+=$'\n'"# allow outbound services:"
 		firewall_script+=$'\n'"iptables -A OUTPUT -o ${selected_lan_interfaces[0]} -p icmp -m comment --comment \"icmp\" -j ACCEPT"
-		firewall_script+=$'\n'"iptables -A OUTPUT -o ${selected_lan_interfaces[0]} -p udp -m multiport --dports \$OPENVPN_UDP_PORTS -m comment --comment \"openvpn\" -j ACCEPT"
+		if [ -n "$OPENVPN_TCP_PORTS" ]; then
+		firewall_script+=$'\n'"iptables -A OUTPUT -o ${selected_lan_interfaces[0]} -p tcp -m multiport --dports $OPENVPN_TCP_PORTS -m comment --comment \"openvpn tcp\" -j ACCEPT"
+		fi
+		if [ -n "$OPENVPN_UDP_PORTS" ]; then
+		firewall_script+=$'\n'"iptables -A OUTPUT -o ${selected_lan_interfaces[0]} -p udp -m multiport --dports $OPENVPN_UDP_PORTS -m comment --comment \"openvpn udp\" -j ACCEPT"
+		fi
 		firewall_script+=$'\n'"iptables -A OUTPUT -o ${selected_lan_interfaces[0]} -p tcp -m tcp --sport 22 -m comment --comment \"ssh\" -j ACCEPT"
 		firewall_script+=$'\n'"iptables -A OUTPUT -o ${selected_lan_interfaces[0]} -p udp -m udp --dport 123 -m comment --comment \"ntp\" -j ACCEPT"
 		firewall_script+=$'\n'"iptables -A OUTPUT -o ${selected_lan_interfaces[0]} -p udp -m udp --dport 53 -m comment --comment \"dns\" -j ACCEPT"


### PR DESCRIPTION
As discussed in #40, submitting a tweak to add common TCP ports to FW script

In current state, the VPN switch does not change the protocol at all, so it remains whatever was chosen in the original server.conf, so my guess is anyone using this currently is locked to a single choice of protocol and switching servers within that protocol

As a first subsequent step, I will test if the FW script can be applied to discover protocol and ports from the current server.conf after every switch and tweak a user-defined chain based on that. If that works, the FW config can be isolated from switching step. As an additional step, then the vpnserves config can be enhanced to optionally include the protocol per server, which can then be used to rewrite the servers.conf

I will try out this when I get some downtime, and follow up on this thread
